### PR TITLE
Initialize Adafruit GFX lib with real screen width

### DIFF
--- a/PxMatrix.cpp
+++ b/PxMatrix.cpp
@@ -82,25 +82,25 @@ void PxMATRIX::setFastUpdate(bool fast_update) {
   _fast_update=fast_update;
 }
 
-PxMATRIX::PxMATRIX(uint8_t width, uint8_t height,uint8_t LATCH, uint8_t OE, uint8_t A,uint8_t B) : Adafruit_GFX(width+10, height)
+PxMATRIX::PxMATRIX(uint8_t width, uint8_t height,uint8_t LATCH, uint8_t OE, uint8_t A,uint8_t B) : Adafruit_GFX(width, height)
 {
   init(width, height, LATCH, OE, A, B);
 }
 
-PxMATRIX::PxMATRIX(uint8_t width, uint8_t height,uint8_t LATCH, uint8_t OE, uint8_t A,uint8_t B,uint8_t C) : Adafruit_GFX(width+10, height)
+PxMATRIX::PxMATRIX(uint8_t width, uint8_t height,uint8_t LATCH, uint8_t OE, uint8_t A,uint8_t B,uint8_t C) : Adafruit_GFX(width, height)
 {
   _C_PIN = C;
   init(width, height, LATCH, OE, A, B);
 }
 
-PxMATRIX::PxMATRIX(uint8_t width, uint8_t height,uint8_t LATCH, uint8_t OE, uint8_t A,uint8_t B,uint8_t C,uint8_t D) : Adafruit_GFX(width+10, height)
+PxMATRIX::PxMATRIX(uint8_t width, uint8_t height,uint8_t LATCH, uint8_t OE, uint8_t A,uint8_t B,uint8_t C,uint8_t D) : Adafruit_GFX(width, height)
 {
   _C_PIN = C;
   _D_PIN = D;
   init(width, height, LATCH, OE, A, B);
 }
 
-PxMATRIX::PxMATRIX(uint8_t width, uint8_t height,uint8_t LATCH, uint8_t OE, uint8_t A,uint8_t B,uint8_t C,uint8_t D, uint8_t E) : Adafruit_GFX(width+10, height)
+PxMATRIX::PxMATRIX(uint8_t width, uint8_t height,uint8_t LATCH, uint8_t OE, uint8_t A,uint8_t B,uint8_t C,uint8_t D, uint8_t E) : Adafruit_GFX(width, height)
 {
   _C_PIN = C;
   _D_PIN = D;


### PR DESCRIPTION
I'm not sure why this tweak was here, but having the screen width passed into adafruit gfx lib 10 larger than the actual screen width causes loss of characters written to the screen if automatic wrapping is enabled.