### PR TITLE
Use recognized license title

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-Software License Agreement (BSD License)
+BSD 3-Clause License
 
 Copyright (c) 2012, Adafruit Industries
 All rights reserved.


### PR DESCRIPTION
GitHub uses the [licensee](https://github.com/benbalter/licensee) ruby gem to detect the license type of the repository. licensee [uses](https://github.com/benbalter/licensee/blob/master/docs/what-we-look-at.md#known-licenses) the license texts from [choosealicense.com](https://choosealicense.com/) so if the text of your license file differs from their license it will not be recognized. GitHub allows [filtering searches by license type](https://blog.github.com/2017-11-03-search-repositories-by-license/) and also shows the license type on the homepage of your repository and when viewing the license page but these features are only available when the license is recognized.