### PR TITLE
Make double buffering more obvious

### DIFF
--- a/PxMatrix.h
+++ b/PxMatrix.h
@@ -461,7 +461,7 @@ inline PxMATRIX::PxMATRIX(uint16_t width, uint16_t height,uint8_t LATCH, uint8_t
 }
 
 inline void PxMATRIX::drawPixel(int16_t x, int16_t y, uint16_t color) {
-  drawPixelRGB565( x,  y,  color,0 );
+  drawPixelRGB565( x,  y,  color, _selected_buffer );
 }
 
 inline void PxMATRIX::drawPixel(int16_t x, int16_t y, uint16_t color, bool selected_buffer) {


### PR DESCRIPTION
If not defined, only one buffer is created and ever used. On the other hand,
highest index in PxMATRIX_buffer is used to differentiate buffers.

Drawing is always done on inactive (selected) buffer. Display always shows active buffer. Those are swapped on explicit call by the user with swapBuffers. By default everything works as it did, swapBuffers have no effect and drawing as well as showing is done from the same buffer.

Change simplifies notation and operations on the buffers itself. It might be useful to exchange define name for something more "official" like PxMATRIX_USE_DOUBLE_BUFFER.