### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Adafruit GFX compatible library for 32x16, 32x32, 64x32, 64x64 RGB mat
 category=Display
 url=https://github.com/2dom/PxMatrix
 architectures=*
+depends=Adafruit GFX Library


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format