### PR TITLE
Support for ABC-Panels 

### DIFF
--- a/PxMatrix.h
+++ b/PxMatrix.h
@@ -116,7 +116,7 @@ BSD license, check license.txt for more information
 
 // Either the panel handles the multiplexing and we feed BINARY to A-E pins
 // or we handle the multiplexing and activate one of A-D pins (STRAIGHT)
-enum mux_patterns {BINARY, STRAIGHT};
+enum mux_patterns {BINARY, STRAIGHT, ABC};
 
 // This is how the scanning is implemented. LINE just scans it left to right,
 // ZIGZAG jumps 4 rows after every byte, ZAGGII alse revereses every second byte
@@ -910,6 +910,21 @@ void PxMATRIX::begin(uint8_t row_pattern) {
 
 void PxMATRIX::set_mux(uint8_t value)
 {
+
+  if (_mux_pattern==ABC)
+  {
+    for (int activate = 0; activate < _row_pattern; activate++) {
+      digitalWrite(_A_PIN,LOW);
+      if (activate == _row_pattern - 1 - value) {
+        digitalWrite(_C_PIN,HIGH);
+      } else {
+        digitalWrite(_C_PIN,LOW);
+      }
+      digitalWrite(_A_PIN,HIGH);
+    }
+    digitalWrite(_C_PIN,LOW);
+    digitalWrite(_A_PIN,LOW);
+  }
 
   if (_mux_pattern==BINARY)
   {


### PR DESCRIPTION
Hi and thanks for this awesome library!

I have a [P2-128x64-32S-4.0](https://www.aliexpress.com/item/32991231693.html?spm=a2g0s.9042311.0.0.54d14c4d9FxEko) Panel from Aliexpress.

I added a MUX variant for this panel using the algorithm of @mcpgza who [fixed](https://github.com/hzeller/rpi-rgb-led-matrix/issues/823#issuecomment-535677308) these panels in the RPi Matrix Library by @hzeller. Now I would like to use a ESP8266 to drive this panel.

The only problem right now is that the middle line (32) is shifted to the last line (64).

![alt text](https://dev.themultiplexer.eu/shiftedline.jpeg "Shifted Lines")

[And here is a demo video](https://dev.themultiplexer.eu/demo.mov)

Furthermore it only works with display_ticker interval 0.01 but not faster.

Maybe you @2dom or anybody else knows how to fix it.

