### PR TITLE
Shiftreg binary

### DIFF
--- a/PxMatrix.h
+++ b/PxMatrix.h
@@ -322,7 +322,7 @@ inline void init(uint16_t width, uint16_t height ,uint8_t LATCH, uint8_t OE, uin
 inline void latch(uint16_t show_time );
 
   // Set row multiplexer
-inline void set_mux(uint8_t value, boolean random_access);
+inline void set_mux(uint8_t value, bool random_access);
 
 inline void spi_init();
 
@@ -946,7 +946,7 @@ void PxMATRIX::begin(uint8_t row_pattern) {
 
 }
 
-void PxMATRIX::set_mux(uint8_t value, boolean random_access = false)
+void PxMATRIX::set_mux(uint8_t value, bool random_access = false)
 {
 
   if (_mux_pattern==BINARY)

--- a/PxMatrix.h
+++ b/PxMatrix.h
@@ -122,8 +122,9 @@ BSD license, check license.txt for more information
 // BINARY: Pins A-E map to rows 1-32 via binary decoding (default)
 // STRAIGHT: Pins A-D are directly mapped to rows 1-4
 // SHIFTREG: A, B, C on Panel are connected to a shift register Clock, /Enable, Data
+// SHIFTREG_ABC_BIN_DE: A-C are connected to Shift-Register Clock, Data, /Enable, D-E to binary decoder (crazy shit)
 // SHIFTREG_SPI_SE: Like SHIFTREG, but you connect A and C on Panel to its Clock and Data output (and ground B). This will not work with fast_update enabled!
-enum mux_patterns {BINARY, STRAIGHT, SHIFTREG_ABC, SHIFTREG_SPI_SE};
+enum mux_patterns {BINARY, STRAIGHT, SHIFTREG_ABC, SHIFTREG_SPI_SE, SHIFTREG_ABC_BIN_DE};
 
 // This is how the scanning is implemented. LINE just scans it left to right,
 // ZIGZAG jumps 4 rows after every byte, ZAGGII alse revereses every second byte
@@ -1040,6 +1041,28 @@ void PxMATRIX::set_mux(uint8_t value, boolean random_access = false)
     } else {
       // Just shift the row mux by one for incremental access
       digitalWrite(_C_PIN, (value==0) ); // Shift out 1 for line 0, 0 otherwise
+      digitalWrite(_A_PIN, HIGH); // Clock out this bit
+      digitalWrite(_A_PIN, LOW);
+    }
+  }
+
+  if (_mux_pattern==SHIFTREG_ABC_BIN_DE) {
+    // A-C are connected to Shift-Register Clock, Data, /Enable, D-E to binary decoder (crazy shit)
+    // Shift-Register is 8 rows wide, D-E select different Blocks of 8 rows
+    digitalWrite(_D_PIN, (value>>3)&1 );
+    digitalWrite(_E_PIN, (value>>4)&1 );
+    value = value % 8;
+    if(random_access) {
+      // Clock out all row mux bits to make sure random access is possible
+      uint8_t r = 8;
+      while(r-- > 0) {
+        digitalWrite(_B_PIN, (value==r) ); // Shift out 1 for selected row
+        digitalWrite(_A_PIN, HIGH); // Clock out this bit
+        digitalWrite(_A_PIN, LOW);
+      }
+    } else {
+      // Just shift the row mux by one for incremental access
+      digitalWrite(_B_PIN, (value==0) ); // Shift out 1 for line 0, 0 otherwise
       digitalWrite(_A_PIN, HIGH); // Clock out this bit
       digitalWrite(_A_PIN, LOW);
     }

--- a/PxMatrix.h
+++ b/PxMatrix.h
@@ -546,6 +546,16 @@ inline void PxMATRIX::setMuxPattern(mux_patterns mux_pattern)
     pinMode(_C_PIN, OUTPUT); // C is used as MUX_DATA
     digitalWrite(_B_PIN,LOW); // Enable output of row mux
   }
+
+  if (_mux_pattern==SHIFTREG_ABC_BIN_DE)
+  {
+    pinMode(_A_PIN, OUTPUT); // A is used as MUX_CLK
+    pinMode(_B_PIN, OUTPUT); // B is used as MUX_DATA
+    pinMode(_C_PIN, OUTPUT); // C is used as MUX_ENABLE
+    pinMode(_D_PIN, OUTPUT); // D is 4th bit of row
+    pinMode(_E_PIN, OUTPUT); // E is 5th bit of row
+    digitalWrite(_C_PIN,LOW); // Enable output of row mux
+  }
 }
 
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ SHIFTREG_ABC (with RT5957 or other Shift-Register for row selection) will requir
 ### SHIFTREG_SPI_SE - for RT5957 panels (experimental)
 SHIFTREG_SPI_SE is a functionally identical variant of SHIFTREG_ABC where we use the SPI signal carrying the display data also for the row selection logic. This frees up three exta I/O pins required by SHIFTREG_ABC. To make this work you will have to connect the outputs of your last panel to the ABC inputs of the first panel - in particular A (IN) needs to be connected to Clock (OUT), C (IN) to Data/Blue_2 (OUT), B (IN) to GND. 
 
+### SHIFTREG_ABC_BIN_DE
+SHIFTREG_ABC_BIN_DE is for really weird panels using a combination of Shift-Register (e.g. SM5266PH) and also binary decoding for addressing the rows. A,B,C are connected to a 8 rows wide Shift-register Clock, Data, /Enable. Additionally, D-E control which block of 8 rows is used through binary decoding. This is for 1/16 and 1/32 panels only.
+
 ## Colors
 The number of color levels can be selected in the header file. The default (8 color levels per primary RGB color) works well with hardly any flickering. Note that the number of color levels determines the achievable display refresh rate. Hence, the more color levels are selected, the more flickering is to be expected. If you run into problems with flickering it is a good idea to increase the CPU frequency to 160MHz. This way the processor has more headroom to compute the display updates and refresh the display in time.
 


### PR DESCRIPTION
Add `SHIFTREG_ABC_BIN_DE` for panels that use combination of shift register and binary decoding for row selection. See #209 